### PR TITLE
Skip Ogg detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ message(STATUS "Configuring ${PROJECT_NAME} ${PROJECT_VERSION}")
 
 check_library_exists(m floor "" HAVE_LIBM)
 
-# Find ogg dependency
-find_package(Ogg REQUIRED)
+# Skip finding Ogg dependency because it's already in project source
+# find_package(Ogg REQUIRED)
 
 add_subdirectory(lib)
 


### PR DESCRIPTION
On CI machines the build failed because Ogg library was not found